### PR TITLE
Add demo for login-fire wrapped in paper-dialog

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -24,6 +24,7 @@
     "iron-component-page": "PolymerElements/iron-component-page#^1.0.0",
     "iron-demo-helpers": "PolymerElements/iron-demo-helpers#^1.0.0",
     "web-component-tester": "^4.0.0",
-    "webcomponentsjs": "webcomponents/webcomponentsjs#^0.7.0"
+    "webcomponentsjs": "webcomponents/webcomponentsjs#^0.7.0",
+    "paper-dialog": "PolymerElements/paper-dialog#^1.0.4"
   }
 }

--- a/demo/index.html
+++ b/demo/index.html
@@ -11,6 +11,7 @@
 
     <link rel="import" href="../login-fire.html">
     <link rel="import" href="../../polymerfire/firebase-app.html">
+    <link rel="import" href="../../paper-dialog/paper-dialog.html">
 
     <style is="custom-style" include="demo-pages-shared-styles">
     </style>
@@ -25,8 +26,7 @@
             name="narrowDemo"
             api-key="AIzaSyACU-9dEBSmlEq8iwfuDCPCWU81UNDytuQ"
             auth-domain="convoofire.firebaseapp.com"
-            database-url="https://convoofire.firebaseio.com"
-          >
+            database-url="https://convoofire.firebaseio.com">
           </firebase-app>
           <login-fire email-password anonymous twitter github google facebook app-name="narrowDemo"></login-fire>
         </template>
@@ -158,6 +158,24 @@
           >
           </firebase-app>
           <login-fire reverse email-password anonymous twitter github google facebook app-name="reverseWideDemo"></login-fire>
+        </template>
+      </demo-snippet>
+    </div>
+
+    <div class="vertical-section-container centered">
+      <h3>login-fire in modal demo </h3>
+      <demo-snippet>
+
+        <paper-button raised onclick="dialog.open()">login-fire in modal</paper-button>
+
+        <template>
+          <paper-dialog id="dialog" with-backdrop center>
+            <paper-dialog-scrollable>
+              <firebase-app name="modalDemo" api-key="AIzaSyACU-9dEBSmlEq8iwfuDCPCWU81UNDytuQ" auth-domain="convoofire.firebaseapp.com" database-url="https://convoofire.firebaseio.com">
+              </firebase-app>
+              <login-fire reverse email-password anonymous twitter github google facebook app-name="modalDemo"></login-fire>
+            </paper-dialog-scrollable>
+          </paper-dialog>
         </template>
       </demo-snippet>
     </div>


### PR DESCRIPTION
Added demo for login-fire wrapped in paper-dialog. Is not working as expected. Pushing for you to review and maybe have some clue what is up with it. 

<img width="1136" alt="screen shot 2016-07-07 at 10 15 31 pm" src="https://cloud.githubusercontent.com/assets/460336/16675597/72072266-4490-11e6-89ee-505ab4d21a1f.png">
