### PR TITLE
Adding programmatical signin

### DIFF
--- a/login-fire-common-behavior.html
+++ b/login-fire-common-behavior.html
@@ -125,7 +125,7 @@ LICENSE file or at https://github.com/convoo/login-fire/blob/master/LICENSE.
       },
 
       /**
-       * Sets the path to the locales json file 
+       * Sets the path to the locales json file
        * where the specific text to use is stored
        *
        * @type {String}
@@ -424,13 +424,13 @@ LICENSE file or at https://github.com/convoo/login-fire/blob/master/LICENSE.
      */
   };
 
-  
+
     /**
     * @polymerBehavior
     */
     Convoo.LoginFireCommonBehavior = [
         Polymer.AppLocalizeBehavior,
         Convoo.LoginFireCommonBehaviorImpl
-    ];  
+    ];
 }());
 </script>

--- a/login-fire-form.html
+++ b/login-fire-form.html
@@ -28,7 +28,7 @@ Example:
 
 ### Styling
 
-Style the buttons with CSS as you would a normal DOM element. 
+Style the buttons with CSS as you would a normal DOM element.
 
 The following custom properties and mixins are available for styling:
 
@@ -166,7 +166,7 @@ You can specify the following codes and language in a json file passed to the lo
                 on-keydown="_submitOnEnter"
                 required>
                 <template is="dom-if" if="[[!noToggleablePassword]]">
-                    <paper-icon-button 
+                    <paper-icon-button
                         id="passwordIconButton"
                         suffix
                         on-down="_revealPW"
@@ -203,7 +203,7 @@ You can specify the following codes and language in a json file passed to the lo
                 <div class="action">
                     <paper-button raised$="[[!flat]]" type="submit" on-tap="_signIn" class="btn--signin">[[localize('lf-signin-button')]]</paper-button>
                 </div>
-                
+
                 <template is="dom-if" if="[[!noSignUp]]">
                     <p class="signup-toggle">
                         [[localize('lf-no-account')]] <a on-tap="_toggleShowSignUp" tabindex="0" title="[[localize('lf-no-account')]] [[localize('lf-no-account-action')]]" href="#" on-tap="">[[localize('lf-no-account-action')]]</a>
@@ -317,7 +317,7 @@ You can specify the following codes and language in a json file passed to the lo
     /**
      * Tries to sign in a user using the form values.
      */
-    _signIn: function() {
+    signIn: function() {
       this._cleanMessages();
       e = this.$$("#emailInput").validate();
       p = this.$$("#passwordInput").validate();
@@ -376,7 +376,7 @@ You can specify the following codes and language in a json file passed to the lo
      */
     _resetPassword: function() {
       this._cleanMessages();
-      e = this.$$("#resetEmailInput").validate() 
+      e = this.$$("#resetEmailInput").validate()
       if (e){
         this.$$("#auth").auth.sendPasswordResetEmail(this.email).then(function() {
             this.set('_lastMessage', this.localize('lf-resetpw-success-message'));

--- a/login-fire-social.html
+++ b/login-fire-social.html
@@ -96,6 +96,7 @@ You can specify the following codes and language in a json file passed to the lo
     <template is="dom-if" if="[[!_showOneButton]]">
         <template is="dom-repeat" items="{{_providers}}">
             <login-fire-button
+                id="lfb[[item.id]]"
                 app-name="[[appName]]"
                 provider="[[item.id]]"
                 user="{{_user}}"
@@ -176,6 +177,18 @@ You can specify the following codes and language in a json file passed to the lo
      */
     signOut: function() {
       this.$$('login-fire-button').signOut();
+    },
+
+    /**
+     * Signs the user in using the target provider.
+     *
+     * @param  {String} provider name
+     */
+    signInWith: function(provider) {
+      var btn = this.$$('#lfb' + provider);
+      if (btn) {
+        btn.signIn();
+      }
     },
 
     /**

--- a/login-fire.html
+++ b/login-fire.html
@@ -31,7 +31,7 @@ Example:
 
 ### Styling
 
-Style the buttons with CSS as you would a normal DOM element. 
+Style the buttons with CSS as you would a normal DOM element.
 
 The following custom properties and mixins are available for styling:
 
@@ -313,6 +313,29 @@ You can specify the following codes and language in a json file passed to the lo
      */
     signOut: function() {
       this.$$('login-fire-social').signOut();
+    },
+
+    /**
+     * Signs the user in using the target provider. It's not possible to sign in
+     * using the provider "password" when only one button is displayed. Also,
+     * does nothing if a user is already signed in.
+     *
+     * @param  {String} provider name
+     */
+    signInWith: function(provider) {
+      if (this.signedIn) {
+        return;
+      }
+
+      if (provider === 'password') {
+        if (this._showOneButton) {
+          console.error("Can't sign in using provider \"password\" when only one button is displayed.");
+        } else {
+          this.$$('login-fire-form').signIn();
+        }
+      } else {
+        this.$$('login-fire-social').signInWith(provider);
+      }
     },
 
     /**


### PR DESCRIPTION
With this commit it's possible to sign in programmatically using the
"signInWith" method of the `login-fire-social` element.

The `login-fire-form` element and the super-element `login-fire` are now
able to signin programmatically too.

Close #95