### PR TITLE
fix: remove unused attributes

### DIFF
--- a/login-fire.html
+++ b/login-fire.html
@@ -168,7 +168,6 @@ You can specify the following codes and language in a json file passed to the lo
                 signed-in="{{_signedIn}}"
                 status-known="{{_statusKnown}}"
                 auto-sign-up="[[autoSignUp]]"
-                can-sign-out="[[canSignOut]]"
                 show-sign-up="{{showSignUp}}"
                 flat="{{flat}}"
                 locales-file="[[localesFile]]"


### PR DESCRIPTION
It seems during [commit of refactoring](https://github.com/convoo/login-fire/commit/0fdad26e46e9f24e49f6c3281785c9c1d08f62e5#diff-9e71d9176de61388aeb403b153e2bf38R173), some attributes were missed.
This commit removes unused attributes.