### PR TITLE
Upgrade app-localize-behavior dependency

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -20,7 +20,7 @@
     "paper-input": "PolymerElements/paper-input#^1.1.11",
     "paper-button": "PolymerElements/paper-button#^1.0.12",
     "iron-media-query": "PolymerElements/iron-media-query#^1.0.8",
-    "app-localize-behavior": "PolymerElements/app-localize-behavior#^0.10.1",
+    "app-localize-behavior": "PolymerElements/app-localize-behavior#^1.0.0",
     "paper-icon-button": "PolymerElements/paper-icon-button#^1.1.4",
     "iron-icon": "PolymerElements/iron-icon#^1.0.12",
     "reverse-element": "convoo/reverse-element#^0.0.4"


### PR DESCRIPTION
The dependency `app-localize-behavior` used to localize all texts of the
`login-fire` component was upgraded to fix issue on Safari.

fixes #107