### PR TITLE
fix(style): divider word properly aligned

### DIFF
--- a/login-fire.html
+++ b/login-fire.html
@@ -103,10 +103,10 @@ You can specify the following codes and language in a json file passed to the lo
     }
     .div {
       @apply(--layout-center-center);
-      border-color: var(--login-fire-divider-color, lightgray);
+      background-color: var(--login-fire-divider-color, lightgray);
     }
     .div__span {
-      line-height: 0px;
+      line-height: 15px;
       padding: 16px;
       background: var(--login-fire-background-color, white);
       font-size: 12px;
@@ -124,7 +124,6 @@ You can specify the following codes and language in a json file passed to the lo
     }
     .div--vertical {
       @apply(--layout-horizontal);
-      border-right: 1px solid lightgray;
       margin: 0 50px;
       min-height: 200px;
       max-height: 400px;
@@ -132,7 +131,6 @@ You can specify the following codes and language in a json file passed to the lo
     }
     .div--horizontal {
       @apply(--layout-vertical);
-      border-top: 1px solid lightgray;
       height: 1px;
       margin: 50px 0;
       min-width: 300px;


### PR DESCRIPTION
Before this commit, for drawing a stripe to split the panel in 2 parts,
we were using border of a div tag. It introduces issue for aligning
the word "or" displayed on the middle of this one.

Now we are using background color that is easier to see the
representation in (our?) my mind. Because the stripe thickness is 1px,
if we want to have the same number of pixels on each sides the line
height of the word has to be odd. The original height was 14px so I've
simply increased by 1px to not modify too much the display.

fixes #123