### PR TITLE
Show progress bar in buttons when clicked

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -26,7 +26,8 @@
     "paper-icon-button": "PolymerElements/paper-icon-button#1 - 2",
     "iron-icon": "PolymerElements/iron-icon#1 - 2",
     "iron-iconset-svg": "PolymerElements/iron-iconset-svg#1 - 2",
-    "reverse-element": "convoo/reverse-element#^0.0.6"
+    "reverse-element": "convoo/reverse-element#^0.0.6",
+    "paper-progress": "^2.0.1"
   },
   "devDependencies": {
     "iron-component-page": "PolymerElements/iron-component-page#1 - 2",

--- a/demo/login-fire-social.html
+++ b/demo/login-fire-social.html
@@ -131,13 +131,15 @@ LICENSE file or at https://github.com/convoo/login-fire/blob/master/LICENSE.
         <style is="custom-style">
         login-fire-social.custom {
           width: 100%;
+          --paper-progress-active-color: darkred;
+          --paper-progress-secondary-color: lightred;
           --login-fire-button-text:{
             font-size: 12px;
             font-weight: bold;
-          }
+          };
           --login-fire-button-icon:{
             display: none
-          }
+          };
         }
         </style>
       </template>

--- a/demo/login-fire.html
+++ b/demo/login-fire.html
@@ -132,10 +132,14 @@ LICENSE file or at https://github.com/convoo/login-fire/blob/master/LICENSE.
           --paper-input-container-color: #a58e7a;
           --paper-input-container-focus-color: #fecea8;
           --paper-input-container-input-color: white;
-          --paper-progress-active-color: orangered;
-          --paper-progress-container-color: whitesmoke;
+          --login-fire-progress-active-color: orangered;
+          --login-fire-progress-container-color: #2a363b;
           --login-fire-form: {
             width: 400px;
+          };
+          --login-fire-button-facebook: {
+            --login-fire-progress-active-color: orangered;
+            --login-fire-progress-container-color: blue;
           };
           --login-fire-form-toggle: {
             color: #a58e7a;

--- a/demo/login-fire.html
+++ b/demo/login-fire.html
@@ -133,7 +133,7 @@ LICENSE file or at https://github.com/convoo/login-fire/blob/master/LICENSE.
           --paper-input-container-focus-color: #fecea8;
           --paper-input-container-input-color: white;
           --paper-progress-active-color: orangered;
-          --paper-progress-secondary-color: whitesmoke;
+          --paper-progress-container-color: whitesmoke;
           --login-fire-form: {
             width: 400px;
           };

--- a/demo/login-fire.html
+++ b/demo/login-fire.html
@@ -132,6 +132,8 @@ LICENSE file or at https://github.com/convoo/login-fire/blob/master/LICENSE.
           --paper-input-container-color: #a58e7a;
           --paper-input-container-focus-color: #fecea8;
           --paper-input-container-input-color: white;
+          --paper-progress-active-color: orangered;
+          --paper-progress-secondary-color: whitesmoke;
           --login-fire-form: {
             width: 400px;
           };

--- a/login-fire-button.html
+++ b/login-fire-button.html
@@ -131,11 +131,12 @@ custom properties and mixins are available:
         @apply --login-fire-btn-signout-hover;
       }
 
-      paper-progress {
+      .btn-progress {
         position: absolute;
         left: 0;
         bottom: 0;
         width: 100%;
+        @apply --login-fire-button-progress;
       }
 
       [hidden] {
@@ -147,7 +148,7 @@ custom properties and mixins are available:
       <iron-icon class="btn__icon" icon="login-fire-icons:[[provider]]" hidden$="[[_hideIcon]]"></iron-icon>
       <iron-icon class="btn__icon" icon="login-fire-icons:logout" hidden$="[[!_hideIcon]]"></iron-icon>
       <span class="btn__text">[[_text]]</span>
-      <paper-progress hidden$="[[!_inProgress]]" disabled$="[[!_inProgress]]" indeterminate></paper-progress>
+      <paper-progress class="btn-progress" hidden$="[[!_inProgress]]" disabled$="[[!_inProgress]]" indeterminate></paper-progress>
     </paper-button>
 
     <firebase-auth id="auth"

--- a/login-fire-button.html
+++ b/login-fire-button.html
@@ -143,11 +143,11 @@ custom properties and mixins are available:
       }
     </style>
 
-    <paper-button class$="btn btn--[[provider]] [[_miniClass]] [[_signOutClass]]" raised$="[[!flat]]" disabled="[[_computedButtonDisabled(_progress, disabled)]]">
+    <paper-button class$="btn btn--[[provider]] [[_miniClass]] [[_signOutClass]]" raised$="[[!flat]]" disabled$="[[_inProgress]]">
       <iron-icon class="btn__icon" icon="login-fire-icons:[[provider]]" hidden$="[[_hideIcon]]"></iron-icon>
       <iron-icon class="btn__icon" icon="login-fire-icons:logout" hidden$="[[!_hideIcon]]"></iron-icon>
       <span class="btn__text">[[_text]]</span>
-      <paper-progress hidden$="[[!_spinnerVisible]]" disabled$="[[!_spinnerVisible]]" indeterminate></paper-progress>
+      <paper-progress hidden$="[[!_inProgress]]" disabled$="[[!_inProgress]]" indeterminate></paper-progress>
     </paper-button>
 
     <firebase-auth id="auth"
@@ -213,23 +213,11 @@ custom properties and mixins are available:
       _text: {
         type: String,
         computed: '_computeButtonText(config.provider, showSignUp, noSignIn, noSignOut, signedIn, localize, language)'
-      },
-      /** True if the button can't be pressed */
-      disabled: {
-        type: Boolean,
-        value: false,
-      },
-      _spinnerVisible: {
-        type: Boolean,
-        computed: '_computeSpinnerVisible(_progress, disabled)'
       }
     },
 
     listeners: {
-      'click': 'signInOrOut',
-      'signedin': 'progressChanged',
-      'signedout': 'progressChanged',
-      'error': 'progressChanged'
+      'click': 'signInOrOut'
     },
 
     /**
@@ -296,17 +284,6 @@ custom properties and mixins are available:
         // User has account
         return localize('lf-signin-' + provider.id);
       }
-    },
-    progressChanged: function(event) {
-      this._progress = false;
-      console.log(event);
-      console.log('Sign in or sign out is complete');
-    },
-    _computedButtonDisabled: function(_progress, disabled) {
-      return _progress || disabled;
-    },
-    _computeSpinnerVisible: function(_progress, disabled) {
-      return _progress && !disabled;
     }
   });
   </script>

--- a/login-fire-button.html
+++ b/login-fire-button.html
@@ -11,6 +11,7 @@ LICENSE file or at https://github.com/convoo/login-fire/blob/master/LICENSE.
 <link rel="import" href="./login-fire-styles.html">
 <link rel="import" href="../iron-icon/iron-icon.html">
 <link rel="import" href="./icons.html">
+<link rel="import" href="../paper-progress/paper-progress.html">
 
 <!--
 A button to authenticate a user with a federated identity provider such as Google, Facebook, Twitter or GitHub.
@@ -130,15 +131,23 @@ custom properties and mixins are available:
         @apply --login-fire-btn-signout-hover;
       }
 
+      paper-progress {
+        position: absolute;
+        left: 0;
+        bottom: 0;
+        width: 100%;
+      }
+
       [hidden] {
         display: none !important;
       }
     </style>
 
-    <paper-button class$="btn btn--[[provider]] [[_miniClass]] [[_signOutClass]]" raised$="[[!flat]]">
+    <paper-button class$="btn btn--[[provider]] [[_miniClass]] [[_signOutClass]]" raised$="[[!flat]]" disabled="[[_computedButtonDisabled(_progress, disabled)]]">
       <iron-icon class="btn__icon" icon="login-fire-icons:[[provider]]" hidden$="[[_hideIcon]]"></iron-icon>
       <iron-icon class="btn__icon" icon="login-fire-icons:logout" hidden$="[[!_hideIcon]]"></iron-icon>
       <span class="btn__text">[[_text]]</span>
+      <paper-progress hidden$="[[!_spinnerVisible]]" disabled$="[[!_spinnerVisible]]" indeterminate></paper-progress>
     </paper-button>
 
     <firebase-auth id="auth"
@@ -204,11 +213,23 @@ custom properties and mixins are available:
       _text: {
         type: String,
         computed: '_computeButtonText(config.provider, showSignUp, noSignIn, noSignOut, signedIn, localize, language)'
+      },
+      /** True if the button can't be pressed */
+      disabled: {
+        type: Boolean,
+        value: false,
+      },
+      _spinnerVisible: {
+        type: Boolean,
+        computed: '_computeSpinnerVisible(_progress, disabled)'
       }
     },
 
     listeners: {
-      'click': 'signInOrOut'
+      'click': 'signInOrOut',
+      'signedin': 'progressChanged',
+      'signedout': 'progressChanged',
+      'error': 'progressChanged'
     },
 
     /**
@@ -275,7 +296,17 @@ custom properties and mixins are available:
         // User has account
         return localize('lf-signin-' + provider.id);
       }
-
+    },
+    progressChanged: function(event) {
+      this._progress = false;
+      console.log(event);
+      console.log('Sign in or sign out is complete');
+    },
+    _computedButtonDisabled: function(_progress, disabled) {
+      return _progress || disabled;
+    },
+    _computeSpinnerVisible: function(_progress, disabled) {
+      return _progress && !disabled;
     }
   });
   </script>

--- a/login-fire-button.html
+++ b/login-fire-button.html
@@ -131,14 +131,6 @@ custom properties and mixins are available:
         @apply --login-fire-btn-signout-hover;
       }
 
-      .btn-progress {
-        position: absolute;
-        left: 0;
-        bottom: 0;
-        width: 100%;
-        @apply --login-fire-button-progress;
-      }
-
       [hidden] {
         display: none !important;
       }

--- a/login-fire-button.html
+++ b/login-fire-button.html
@@ -58,6 +58,8 @@ custom properties and mixins are available:
 | `--login-fire-button-twitter-hover` | Mixin applied on the Twitter button when mouve hovers it | `{}`
 | `--login-fire-btn-signout` | Mixin applied to the sign-out button | `{}`
 | `--login-fire-btn-signout-hover` | Mixin applied to the sign-out button when mouve hovers it | `{}`
+| `--login-fire-progress-active-color` | The color that is applied to the paper-progress bar as active color | `--google-green-500`
+| `--login-fire-progress-container-color` | The color that is applied to the paper-progress-container | `--google-grey-300`
 
 @customElement
 @polymer

--- a/login-fire-common-behavior.html
+++ b/login-fire-common-behavior.html
@@ -292,7 +292,14 @@ LICENSE file or at https://github.com/convoo/login-fire/blob/master/LICENSE.
         type: Object,
         readOnly: true
       },
-      _progress: {
+
+      /**
+       * The _inProgress indicator shows whether a sign in or sign out process is currently running.
+       *
+       * @type {Boolean}
+       * @default false
+       */
+      _inProgress: {
         type: Boolean,
         value: false
       }
@@ -323,7 +330,8 @@ LICENSE file or at https://github.com/convoo/login-fire/blob/master/LICENSE.
         console.debug('The element ' + this.is + (this.noSignOut ? ' cannot' : ' can') + ' sign out.');
       }
       if (!this.noSignOut && this.signedIn) {
-        this._progress = true;
+        // Set _inProgress flag to true when a signout is started
+        this._inProgress = true;
         this.$.auth.signOut().then(this._fireEvent.bind(this));
       }
     },
@@ -364,6 +372,8 @@ LICENSE file or at https://github.com/convoo/login-fire/blob/master/LICENSE.
         console.debug(error);
       }
       this.fire('error', error);
+      // When an error event was fired, we have to set the _inProgress flag back to false
+      this._inProgress = false;
     },
 
     /**
@@ -395,6 +405,8 @@ LICENSE file or at https://github.com/convoo/login-fire/blob/master/LICENSE.
           console.debug('User signed out from', this.config.provider.name);
         }
       }
+      // When signin or signout event was fired, we have to set the _inProgress flag back to false
+      this._inProgress = false;
     },
 
     /**

--- a/login-fire-common-behavior.html
+++ b/login-fire-common-behavior.html
@@ -291,6 +291,10 @@ LICENSE file or at https://github.com/convoo/login-fire/blob/master/LICENSE.
       resources: {
         type: Object,
         readOnly: true
+      },
+      _progress: {
+        type: Boolean,
+        value: false
       }
     },
 
@@ -319,6 +323,7 @@ LICENSE file or at https://github.com/convoo/login-fire/blob/master/LICENSE.
         console.debug('The element ' + this.is + (this.noSignOut ? ' cannot' : ' can') + ' sign out.');
       }
       if (!this.noSignOut && this.signedIn) {
+        this._progress = true;
         this.$.auth.signOut().then(this._fireEvent.bind(this));
       }
     },

--- a/login-fire-common-behavior.html
+++ b/login-fire-common-behavior.html
@@ -326,16 +326,18 @@ LICENSE file or at https://github.com/convoo/login-fire/blob/master/LICENSE.
      * Starts the sign-out process.
      */
     signOut: function() {
-      if (this.debug) {
-        console.debug('The element ' + this.is + (this.noSignOut ? ' cannot' : ' can') + ' sign out.');
-      }
       // Skip processing of this method when we already have started a sign or signout process
       if (this._inProgress) {
         if (this.debug) {
-          console.log('Ignored signOut when already in progress');
+          console.debug('Ignored signOut when already in progress');
         }
         return;
       }
+
+      if (this.debug) {
+        console.debug('The element ' + this.is + (this.noSignOut ? ' cannot' : ' can') + ' sign out.');
+      }
+
       if (!this.noSignOut && this.signedIn) {
         // Set _inProgress flag to true when a signout is started
         this._inProgress = true;

--- a/login-fire-common-behavior.html
+++ b/login-fire-common-behavior.html
@@ -294,7 +294,7 @@ LICENSE file or at https://github.com/convoo/login-fire/blob/master/LICENSE.
       },
 
       /**
-       * The _inProgress indicator shows whether a sign in or sign out process is currently running.
+       * Indicates if a sign in or sign out process is currently in progress.
        *
        * @type {Boolean}
        * @default false
@@ -328,6 +328,13 @@ LICENSE file or at https://github.com/convoo/login-fire/blob/master/LICENSE.
     signOut: function() {
       if (this.debug) {
         console.debug('The element ' + this.is + (this.noSignOut ? ' cannot' : ' can') + ' sign out.');
+      }
+      // Skip processing of this method when we already have started a sign or signout process
+      if (this._inProgress) {
+        if (this.debug) {
+          console.log('Ignored signOut when already in progress');
+        }
+        return;
       }
       if (!this.noSignOut && this.signedIn) {
         // Set _inProgress flag to true when a signout is started

--- a/login-fire-form-behavior.html
+++ b/login-fire-form-behavior.html
@@ -64,6 +64,7 @@ LICENSE file or at https://github.com/convoo/login-fire/blob/master/LICENSE.
      * @param  {String} password
      */
     signIn: function(email, password) {
+      this._inProgress = true;
       this.$.auth
         .signInWithEmailAndPassword(email, password)
         .then(this._fireEvent.bind(this))
@@ -96,6 +97,7 @@ LICENSE file or at https://github.com/convoo/login-fire/blob/master/LICENSE.
      */
     signUp: function(email, password) {
       if (this.provider === 'email' && !this.noSignUp) {
+        this._inProgress = true;
         this.$.auth
           .createUserWithEmailAndPassword(email, password)
           .then(this._fireEvent.bind(this))

--- a/login-fire-form.html
+++ b/login-fire-form.html
@@ -11,6 +11,7 @@ LICENSE file or at https://github.com/convoo/login-fire/blob/master/LICENSE.
 <link rel="import" href="../paper-icon-button/paper-icon-button.html">
 <link rel="import" href="../paper-input/paper-input.html">
 <link rel="import" href="./icons.html">
+<link rel="import" href="../paper-progress/paper-progress.html">
 
 <!--
 A pre-built login form to authenticate a user with email and password using the
@@ -147,6 +148,12 @@ Example of a valid locales file:
     paper-icon-button {
       color: grey;
     }
+    paper-progress {
+      position: absolute;
+      left: 0;
+      bottom: 0;
+      width: 100%;
+    }
     </style>
 
     <div class="msg msg--error" hidden$="[[!_lastError]]">
@@ -195,8 +202,10 @@ Example of a valid locales file:
           hidden$="[[!reenterPassword]]"
           required>
         </paper-input>
-        <paper-button raised$="[[!flat]]" type="submit" on-click="_signUp"
-          class="btn--signup">[[localize('lf-signup-button')]]</paper-button>
+        <paper-button raised$="[[!flat]]" type="submit" on-click="_signUp" class="btn--signup" disabled$="[[_inProgress]]">
+          <span>[[localize('lf-signup-button')]]</span>
+          <paper-progress hidden$="[[!_inProgress]]" disabled$="[[!_inProgress]]" indeterminate></paper-progress>
+        </paper-button>
         <p class="signup-toggle">
           <span>[[localize('lf-already-have-account')]]</span>
           <paper-button on-click="_toggleShowSignUp" tabindex="0"
@@ -211,8 +220,10 @@ Example of a valid locales file:
             on-click="toggleShowResetPW" tabindex="0" noink>
             [[localize('lf-resetpw-link')]]</paper-button>
         </p>
-        <paper-button raised$="[[!flat]]" type="submit" on-click="_signIn"
-          class="btn--signin">[[localize('lf-signin-button')]]</paper-button>
+        <paper-button raised$="[[!flat]]" type="submit" on-click="_signIn" class="btn--signin" disabled$="[[_inProgress]]">
+          <span>[[localize('lf-signin-button')]]</span>
+          <paper-progress hidden$="[[!_inProgress]]" disabled$="[[!_inProgress]]" indeterminate></paper-progress>
+        </paper-button>
         <template is="dom-if" if="[[!noSignUp]]">
           <p class="signup-toggle">
             <span>[[localize('lf-no-account')]]</span>
@@ -225,8 +236,10 @@ Example of a valid locales file:
     </template>
 
     <template is="dom-if" if="[[showResetPW]]">
-      <paper-button raised$="[[!flat]]" type="submit" on-click="_resetPassword"
-        class="btn--resetpw">[[localize('lf-resetpw-button')]]</paper-button>
+      <paper-button raised$="[[!flat]]" type="submit" on-click="_resetPassword" class="btn--resetpw" disabled$="[[_inProgress]]">
+        <span>[[localize('lf-resetpw-button')]]</span>
+        <paper-progress hidden$="[[!_inProgress]]" disabled$="[[!_inProgress]]" indeterminate></paper-progress>
+      </paper-button>
       <p>
         <paper-button class="link--reset-pw" on-click="toggleShowResetPW"
           tabindex="0" noink>[[localize('lf-resetpw-cancel-link')]]
@@ -441,12 +454,14 @@ Example of a valid locales file:
       this._cleanMessages();
       e = this.$$('#emailInput').validate()
       if (e) {
+        this._inProgress = true;
         this.$$('#auth').auth.sendPasswordResetEmail(this.email)
           .then(function() {
-            this.set('_lastMessage',
-              this.localize('lf-resetpw-success-message'));
+            this.set('_lastMessage', this.localize('lf-resetpw-success-message'));
+            this._inProgress = false;
           }.bind(this), function(error) {
             this.set('_lastError', error.message);
+            this._inProgress = false;
           }.bind(this));
       }
     },

--- a/login-fire-form.html
+++ b/login-fire-form.html
@@ -454,9 +454,11 @@ Example of a valid locales file:
         this.$$('#auth').auth.sendPasswordResetEmail(this.email)
           .then(function() {
             this.set('_lastMessage', this.localize('lf-resetpw-success-message'));
-            this._inProgress = false;
           }.bind(this), function(error) {
             this.set('_lastError', error.message);
+          }.bind(this))
+          .finally(function(){
+            /* Set _inProgress back to false once everything is done */
             this._inProgress = false;
           }.bind(this));
       }

--- a/login-fire-form.html
+++ b/login-fire-form.html
@@ -46,6 +46,8 @@ Custom property | Description | Default
 `--login-fire-info-msg-color` | The color for the info message | `gray`
 `--login-fire-reset-password-color` | The color of reset password text | `gray`
 `--login-fire-reset-password-hover-color` | The color of reset password text when hovered | `gray`
+`--login-fire-progress-active-color` | The color that is applied to the paper-progress bar as active color | `--google-green-500`
+`--login-fire-progress-container-color` | The color that is applied to the paper-progress-container | `--google-grey-300`
 
 
 ### Localization

--- a/login-fire-form.html
+++ b/login-fire-form.html
@@ -148,11 +148,12 @@ Example of a valid locales file:
     paper-icon-button {
       color: grey;
     }
-    paper-progress {
+    .btn-progress  {
       position: absolute;
       left: 0;
       bottom: 0;
       width: 100%;
+      @apply --login-fire-button-progress;
     }
     </style>
 
@@ -204,7 +205,7 @@ Example of a valid locales file:
         </paper-input>
         <paper-button raised$="[[!flat]]" type="submit" on-click="_signUp" class="btn--signup" disabled$="[[_inProgress]]">
           <span>[[localize('lf-signup-button')]]</span>
-          <paper-progress hidden$="[[!_inProgress]]" disabled$="[[!_inProgress]]" indeterminate></paper-progress>
+          <paper-progress class="btn-progress" hidden$="[[!_inProgress]]" disabled$="[[!_inProgress]]" indeterminate></paper-progress>
         </paper-button>
         <p class="signup-toggle">
           <span>[[localize('lf-already-have-account')]]</span>
@@ -222,7 +223,7 @@ Example of a valid locales file:
         </p>
         <paper-button raised$="[[!flat]]" type="submit" on-click="_signIn" class="btn--signin" disabled$="[[_inProgress]]">
           <span>[[localize('lf-signin-button')]]</span>
-          <paper-progress hidden$="[[!_inProgress]]" disabled$="[[!_inProgress]]" indeterminate></paper-progress>
+          <paper-progress class="btn-progress" hidden$="[[!_inProgress]]" disabled$="[[!_inProgress]]" indeterminate></paper-progress>
         </paper-button>
         <template is="dom-if" if="[[!noSignUp]]">
           <p class="signup-toggle">
@@ -238,7 +239,7 @@ Example of a valid locales file:
     <template is="dom-if" if="[[showResetPW]]">
       <paper-button raised$="[[!flat]]" type="submit" on-click="_resetPassword" class="btn--resetpw" disabled$="[[_inProgress]]">
         <span>[[localize('lf-resetpw-button')]]</span>
-        <paper-progress hidden$="[[!_inProgress]]" disabled$="[[!_inProgress]]" indeterminate></paper-progress>
+        <paper-progress class="btn-progress" hidden$="[[!_inProgress]]" disabled$="[[!_inProgress]]" indeterminate></paper-progress>
       </paper-button>
       <p>
         <paper-button class="link--reset-pw" on-click="toggleShowResetPW"

--- a/login-fire-form.html
+++ b/login-fire-form.html
@@ -11,6 +11,7 @@ LICENSE file or at https://github.com/convoo/login-fire/blob/master/LICENSE.
 <link rel="import" href="../paper-icon-button/paper-icon-button.html">
 <link rel="import" href="../paper-input/paper-input.html">
 <link rel="import" href="./icons.html">
+<link rel="import" href="./login-fire-styles.html">
 <link rel="import" href="../paper-progress/paper-progress.html">
 
 <!--
@@ -80,7 +81,7 @@ Example of a valid locales file:
 -->
 <dom-module id="login-fire-form">
   <template>
-    <style>
+    <style include="login-fire-styles">
     :host {
       display: block;
       width: 210px;
@@ -148,13 +149,7 @@ Example of a valid locales file:
     paper-icon-button {
       color: grey;
     }
-    .btn-progress  {
-      position: absolute;
-      left: 0;
-      bottom: 0;
-      width: 100%;
-      @apply --login-fire-button-progress;
-    }
+
     </style>
 
     <div class="msg msg--error" hidden$="[[!_lastError]]">

--- a/login-fire-social-behavior.html
+++ b/login-fire-social-behavior.html
@@ -53,7 +53,8 @@ LICENSE file or at https://github.com/convoo/login-fire/blob/master/LICENSE.
      */
     signIn: function() {
       if (!this.noSignIn) {
-        this._progress = true;
+        // Set _inProgress flag to true when a signin is started
+        this._inProgress = true;
         if (this.debug) {
           console.log('Signing in...');
         }
@@ -79,6 +80,13 @@ LICENSE file or at https://github.com/convoo/login-fire/blob/master/LICENSE.
      * method is called.
      */
     signInOrOut: function() {
+      // Skip processing of this method when we already have started a sign or signout process
+      if (this._inProgress) {
+        if (this.debug) {
+          console.log('Ignored click when already in progress');
+        }
+        return;
+      }
       if (typeof this.user === 'undefined' || this.user == null) {
         this.signIn();
       } else {

--- a/login-fire-social-behavior.html
+++ b/login-fire-social-behavior.html
@@ -52,6 +52,13 @@ LICENSE file or at https://github.com/convoo/login-fire/blob/master/LICENSE.
      * Starts the sign-in process using a federated identity provider.
      */
     signIn: function() {
+      // Skip processing of this method when we already have started a sign or signout process
+      if (this._inProgress) {
+        if (this.debug) {
+          console.log('Ignored signIn when already in progress');
+        }
+        return;
+      }
       if (!this.noSignIn) {
         // Set _inProgress flag to true when a signin is started
         this._inProgress = true;
@@ -80,13 +87,6 @@ LICENSE file or at https://github.com/convoo/login-fire/blob/master/LICENSE.
      * method is called.
      */
     signInOrOut: function() {
-      // Skip processing of this method when we already have started a sign or signout process
-      if (this._inProgress) {
-        if (this.debug) {
-          console.log('Ignored click when already in progress');
-        }
-        return;
-      }
       if (typeof this.user === 'undefined' || this.user == null) {
         this.signIn();
       } else {

--- a/login-fire-social-behavior.html
+++ b/login-fire-social-behavior.html
@@ -53,6 +53,7 @@ LICENSE file or at https://github.com/convoo/login-fire/blob/master/LICENSE.
      */
     signIn: function() {
       if (!this.noSignIn) {
+        this._progress = true;
         if (this.debug) {
           console.log('Signing in...');
         }

--- a/login-fire-styles.html
+++ b/login-fire-styles.html
@@ -10,8 +10,7 @@ LICENSE file or at https://github.com/convoo/login-fire/blob/master/LICENSE.
     .btn--anonymous {
       background-color: #303030;
       color: #ffffff;
-      --paper-progress-active-color: #303030;
-
+      --login-fire-progress-default-active-color: #303030;
     }
     .btn--anonymous:hover {
       background-color: #414040;
@@ -19,8 +18,7 @@ LICENSE file or at https://github.com/convoo/login-fire/blob/master/LICENSE.
     .btn--facebook {
       background-color: #3b5999;
       color: #ffffff;
-      --paper-progress-active-color: #3b5999;
-
+      --login-fire-progress-default-active-color: #3b5999;
     }
     .btn--facebook:hover {
       background-color: #4265b0;
@@ -28,8 +26,7 @@ LICENSE file or at https://github.com/convoo/login-fire/blob/master/LICENSE.
     .btn--github {
       color: black;
       background-color: #f5f5f5;
-      --paper-progress-active-color: black;
-
+      --login-fire-progress-default-active-color: black;
     }
     .btn--github:hover {
       background-color: #ffffff;
@@ -37,8 +34,7 @@ LICENSE file or at https://github.com/convoo/login-fire/blob/master/LICENSE.
     .btn--google {
       color: black;
       background-color: #ffffff;
-      --paper-progress-active-color: black;
-
+      --login-fire-progress-default-active-color: black;
     }
     .btn--mini {
       max-width: 140px;
@@ -46,8 +42,7 @@ LICENSE file or at https://github.com/convoo/login-fire/blob/master/LICENSE.
     .btn--twitter {
       background-color: #55acee;
       color: #ffffff;
-      --paper-progress-active-color: #55acee;
-
+      --login-fire-progress-default-active-color: #55acee;
     }
     .btn--twitter:hover {
       background-color: #5cb9ff;
@@ -58,6 +53,8 @@ LICENSE file or at https://github.com/convoo/login-fire/blob/master/LICENSE.
       bottom: 0;
       width: 100%;
       border-radius: 0px 0px 3px 3px;
+      --paper-progress-active-color: var(--login-fire-progress-active-color, var(--login-fire-progress-default-active-color));
+      --paper-progress-container-color: var(--login-fire-progress-container-color, var(--login-fire-progress-default-container-color));
     }
     </style>
   </template>

--- a/login-fire-styles.html
+++ b/login-fire-styles.html
@@ -10,6 +10,8 @@ LICENSE file or at https://github.com/convoo/login-fire/blob/master/LICENSE.
     .btn--anonymous {
       background-color: #303030;
       color: #ffffff;
+      --paper-progress-active-color: #303030;
+
     }
     .btn--anonymous:hover {
       background-color: #414040;
@@ -17,13 +19,17 @@ LICENSE file or at https://github.com/convoo/login-fire/blob/master/LICENSE.
     .btn--facebook {
       background-color: #3b5999;
       color: #ffffff;
+      --paper-progress-active-color: #3b5999;
+
     }
     .btn--facebook:hover {
       background-color: #4265b0;
     }
     .btn--github {
       color: black;
-      background-color: #f5f5f5
+      background-color: #f5f5f5;
+      --paper-progress-active-color: black;
+
     }
     .btn--github:hover {
       background-color: #ffffff;
@@ -31,6 +37,8 @@ LICENSE file or at https://github.com/convoo/login-fire/blob/master/LICENSE.
     .btn--google {
       color: black;
       background-color: #ffffff;
+      --paper-progress-active-color: black;
+
     }
     .btn--mini {
       max-width: 140px;
@@ -38,9 +46,18 @@ LICENSE file or at https://github.com/convoo/login-fire/blob/master/LICENSE.
     .btn--twitter {
       background-color: #55acee;
       color: #ffffff;
+      --paper-progress-active-color: #55acee;
+
     }
     .btn--twitter:hover {
       background-color: #5cb9ff;
+    }
+    .btn-progress  {
+      position: absolute;
+      left: 0;
+      bottom: 0;
+      width: 100%;
+      border-radius: 0px 0px 3px 3px;
     }
     </style>
   </template>


### PR DESCRIPTION
This PR should fix issue #64 . Instead of showing a spinner I decided to use a progress bar at the bottom of each button - mainly because I felt it is simpler to style from a layout perspective. The spinner was constantly changing the button size when it appeared.
The progress bar should appear on the following buttons:

- All social logins
- Email sign in
- Email sign up
- Password reset

I added a new `_inProgress` property to _login-fire-common-behavior_ to realize that. Whenever a sign in related process is started, the property is set to true. When a process completes successfully or fails, this property is set back to false. 
The progress bar and its associated buttons then simply react to the state change of this property. 
Styling samples were added to _login-fire_ and _login-fire-social_ pages.