### PR TITLE
fix(provider): quick fix for undefined provider

### DIFF
--- a/login-fire-button.html
+++ b/login-fire-button.html
@@ -263,7 +263,7 @@ custom properties and mixins are available:
      */
     _computeButtonText: function(provider, showSignUp, noSignIn, noSignOut, signedIn, localize, language) {
       // User logged in.
-      if (noSignIn || (!noSignOut && signedIn)) {
+      if (noSignIn || (!noSignOut && signedIn) || !provider) {
         return localize('lf-signout');
       }
 


### PR DESCRIPTION
Since the Polymer 2.4.0 version the login-fire-button encounters an
error when the properties are initialized. This is a weird period when
the properties change from "unset" to the default value. The default
value of default value is `undefined`. Then the computed properties are
computed and binded (at this moment the default provider `anonymous` is
set).

What I mean is the "provider" is undefined only when the element is
initialized and the default value (`anonymous`) not yet computed by
Polymer.

Fixes #156