### PR TITLE
fix(i18n): make resources writable

### DIFF
--- a/login-fire-common-behavior.html
+++ b/login-fire-common-behavior.html
@@ -282,18 +282,6 @@ LICENSE file or at https://github.com/convoo/login-fire/blob/master/LICENSE.
       },
 
       /**
-       * The dictionary of localized messages, for each of the languages that
-       * are going to be used.
-       *
-       * @type {Object}
-       * @default `locales.html` content
-       */
-      resources: {
-        type: Object,
-        readOnly: true
-      },
-
-      /**
        * Indicates if a sign in or sign out process is currently in progress.
        *
        * @type {Boolean}
@@ -310,8 +298,6 @@ LICENSE file or at https://github.com/convoo/login-fire/blob/master/LICENSE.
     attached: function() {
       if (this.localesFile && typeof this.localesFile !== 'undefined') {
         this.loadResources(this.resolveUrl(this.localesFile));
-      } else if (Polymer.Element) {
-        this._setResources(window.Convoo._locales);
       } else {
         this.set('resources', window.Convoo._locales);
       }


### PR DESCRIPTION
Making resources read only prevents the "loadResources" method to actually
set the value of the "resources" property. This commit removes the overwrite
of this property to make it writable again and to let the AppLocalizeBehavior
setting it.

Fixes #167